### PR TITLE
Patch to expose tls_insecure_skip_verify for etcd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 parts
 stage
 prime
+vault*.snap
+snap/.snapcraft

--- a/snap/patches/etcd_export_tls_no_verify.patch
+++ b/snap/patches/etcd_export_tls_no_verify.patch
@@ -1,0 +1,28 @@
+diff --git a/physical/etcd/etcd3.go b/physical/etcd/etcd3.go
+index 94e617997..c03698582 100644
+--- a/physical/etcd/etcd3.go
++++ b/physical/etcd/etcd3.go
+@@ -84,13 +84,22 @@ func newEtcd3Backend(conf map[string]string, logger log.Logger) (physical.Backen
+ 	cert, hasCert := conf["tls_cert_file"]
+ 	key, hasKey := conf["tls_key_file"]
+ 	ca, hasCa := conf["tls_ca_file"]
++	sskip, hasSkip := conf["tls_insecure_skip_verify"]
+ 	if (hasCert && hasKey) || hasCa {
+ 		tls := transport.TLSInfo{
+ 			TrustedCAFile: ca,
+ 			CertFile:      cert,
+ 			KeyFile:       key,
+ 		}
+-
++		if hasSkip {
++			skip, err := strconv.ParseBool(sskip)
++			if err != nil {
++				return nil, errwrap.Wrapf(fmt.Sprintf("value of 'tls_insecure_skip_verify' (%v) could not be understood: {{err}}", sskip), err)
++			}
++			tls.InsecureSkipVerify = skip
++		} else {
++			tls.InsecureSkipVerify = false
++		}
+ 		tlscfg, err := tls.ClientConfig()
+ 		if err != nil {
+ 			return nil, err

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,11 +34,19 @@ parts:
         cd ../src
         git checkout "${last_committed_tag}"
       fi
+      git apply $SNAPCRAFT_STAGE/etcd_export_tls_no_verify.patch
       snapcraftctl build
     plugin: go
     go-importpath: github.com/hashicorp/vault
     go-buildtags: [vault]
     build-packages: [git, g++, libsasl2-dev]
-    after: [go]
+    after:
+      - go
+      - patches
   go:
     source-tag: go1.10.1
+  patches:
+    source: snap/patches
+    plugin: dump
+    prime:
+      - -*


### PR DESCRIPTION
Apply a patch to allow tls_insecure_skip_verify to be set in the
vault etcd backend config. This will cause vault to skip the
validation of the etcd servers TLS cetificate. Specifying
'tls_insecure_skip_verify = "true"' in vaults etcd configuration
works around issue https://github.com/hashicorp/vault/issues/4961