### PR TITLE
Track 1.2.x branch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,7 @@ parts:
     source: https://github.com/hashicorp/vault.git
     override-pull: |
       snapcraftctl pull
+      git checkout --track origin/release/1.2.x
       last_committed_tag="$(git describe --tags --abbrev=0)"
       last_released_tag="$(snap info vault | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to


### PR DESCRIPTION
Ensure that new 1.2.x releases are picked up by tracking
the release branch for the 1.2.x series of Vault.

Once we have tracks setup for 1.1 and 1.2 versions we'll start building from branches for each track.